### PR TITLE
Install libict libraries on a 64 bit system + remove fprintf warning

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,4 +1,4 @@
-# @(#)$Id: Makefile.in 1.81 $
+# @(#)$Id: Makefile.in 1.84 $
 
 #######################################################################
 #
@@ -87,6 +87,7 @@ binprefix =
 
 # Where the installed libraries go.
 libdir = @libdir@
+libdir64 = @libdir@64
 libprefix =
 
 # Where the installed includes go.
@@ -365,6 +366,11 @@ endif
 	@${INSTALL_PROGRAM} $(srcdir)/AuxTools/Mdiff      ${bindir}/${binprefix}Mdiff
 	@${INSTALL_DATA} $(srcdir)/libict.a      ${libdir}/${libprefix}libict.a
 	@if [ -f $(srcdir)/libict.so ]; then ${INSTALL_PROGRAM} $(srcdir)/libict.so ${libdir}/${libprefix}libict.so.1.$(REV); sudo /sbin/ldconfig ${libdir}; cd ${libdir}/; sudo ln -sf ${libprefix}libict.so.1.$(REV) ${libprefix}libict.so; cd -; fi
+ifneq ($(findstring RASPBERRYPI,$(OPT)),RASPBERRYPI)
+	@if [ ! -d ${libdir64} ]; then mkdir -p ${libdir64}; fi
+	@if [ -f $(srcdir)/libict.so ]; then ${INSTALL_PROGRAM} $(srcdir)/libict.so ${libdir64}/${libprefix}libict.so.1.$(REV); sudo /sbin/ldconfig ${libdir64}; cd ${libdir64}/; sudo ln -sf ${libprefix}libict.so.1.$(REV) ${libprefix}libict.so; cd -; fi
+	@${INSTALL_DATA} $(srcdir)/libict.a      ${libdir64}/${libprefix}libict.a
+endif
 	@${INSTALL_DATA} $(srcdir)/icg.h         ${includedir}/${includeprefix}icg.h
 	@${INSTALL_DATA} $(srcdir)/immcc.1.gz    ${mandir}/man1/${manprefix}immcc.1.gz
 	@${INSTALL_DATA} $(srcdir)/immax.1.gz    ${mandir}/man1/${manprefix}immax.1.gz

--- a/src/ict.c
+++ b/src/ict.c
@@ -1,5 +1,5 @@
 static const char ict_c[] =
-"@(#)$Id: ict.c 1.84 $";
+"@(#)$Id: ict.c 1.87 $";
 /********************************************************************
  *
  *	Copyright (C) 1985-2017  John E. Wulff
@@ -3490,7 +3490,7 @@ receiveWatchOrRestore(char * cp1)
 	value = atoi(++cp1);
 	if (index > sTend - sTable || value > 3) {	/* check index is in range, value is correct */
 	  RWRerror:
-	    fprintf(iC_errFP, "Oops: %s: receiveWatchOrRestore: index %d > sTend - sTable %d, value %d > 3\n",
+	    fprintf(iC_errFP, "Oops: %s: receiveWatchOrRestore: index %d > sTend - sTable %ld, value %d > 3\n",
 		iC_iccNM, index, sTend - sTable, value);
 	    continue;			/* ignore this watch/ignore point - check why it failed */
 	}


### PR DESCRIPTION
`Makefile.in`:
When running iClive on a Linux Mint 64 bit distro and compiling a `.ic` file, the make complains since it can't find the necessary `libict.*` libraries in `/usr/local/lib64`.  The current makefile installs those files in `/usr/local/lib` only.
The modification in `Makefile.in` solves this issue.  When not compiling for a Raspberry Pi the directory `/usr/local/lib64` is created if needed and the files `libict.*` are copied to that library directory too (next to copying them to` /usr/local/lib`).

`ict.c`:
Removing a warning: %d was used for a long int while it should be %ld to avoid the warning.